### PR TITLE
Remove metal compiler tool dependency from plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
     ],
     targets: [
-        .plugin(name: "MetalCompilerPlugin", capability: .buildTool(), dependencies: ["MetalCompilerTool"]),
+        .plugin(name: "MetalCompilerPlugin", capability: .buildTool()),
         .executableTarget(name: "MetalCompilerTool", dependencies: [
             .product(name: "ArgumentParser", package: "swift-argument-parser"),
         ]),

--- a/Plugins/MetalCompilerPlugin/MetalPlugin.swift
+++ b/Plugins/MetalCompilerPlugin/MetalPlugin.swift
@@ -5,7 +5,6 @@ import PackagePlugin
 @main
 struct MetalPlugin: BuildToolPlugin {
     func createBuildCommands(context: PackagePlugin.PluginContext, target: PackagePlugin.Target) async throws -> [PackagePlugin.Command] {
-        #if DEBUG
         var paths: [Path] = []
         target.directory.walk { path in
             if path.pathExtension == "metal" {
@@ -13,10 +12,14 @@ struct MetalPlugin: BuildToolPlugin {
             }
         }
         Diagnostics.remark("Running...")
+        guard let metalCompilerTool = try? context.tool(named: "MetalCompilerTool") else {
+            Diagnostics.remark("MetalCompilerTool not found. Skipping plugin build.")
+            return []
+        }
         return [
             .buildCommand(
                 displayName: "Test",
-                executable: try context.tool(named: "MetalCompilerTool").path,
+                executable: metalCompilerTool.path,
                 arguments: [
                     "--output", context.pluginWorkDirectory.appending(["debug.metallib"]).string,
                 ]
@@ -29,9 +32,6 @@ struct MetalPlugin: BuildToolPlugin {
                 ]
             ),
         ]
-        #else
-        return []
-        #endif
     }
 }
 

--- a/Plugins/MetalCompilerPlugin/MetalPlugin.swift
+++ b/Plugins/MetalCompilerPlugin/MetalPlugin.swift
@@ -12,25 +12,27 @@ struct MetalPlugin: BuildToolPlugin {
             }
         }
         Diagnostics.remark("Running...")
-        guard let metalCompilerTool = try? context.tool(named: "MetalCompilerTool") else {
-            Diagnostics.remark("MetalCompilerTool not found. Skipping plugin build.")
-            return []
-        }
+        let arguments = [
+            "metal",
+        ]
+            + [
+                "-o",
+                context.pluginWorkDirectory.appending(["debug.metallib"]).string,
+                "-gline-tables-only",
+                "-frecord-sources",
+            ]
+            + paths.map(\.string)
         return [
             .buildCommand(
                 displayName: "Test",
-                executable: metalCompilerTool.path,
-                arguments: [
-                    "--output", context.pluginWorkDirectory.appending(["debug.metallib"]).string,
-                ]
-                    + paths.map(\.string),
-
+                executable: Path("/usr/bin/xcrun"),
+                arguments: arguments,
                 environment: [:],
                 inputFiles: paths,
                 outputFiles: [
-                    context.pluginWorkDirectory.appending(["debug.metallib"]),
+                    context.pluginWorkDirectory.appending(["debug.metallib"])
                 ]
-            ),
+            )
         ]
     }
 }
@@ -40,7 +42,8 @@ extension Path {
         let errorHandler = { (_: URL, _: Swift.Error) -> Bool in
             true
         }
-        guard let enumerator = FileManager().enumerator(at: url, includingPropertiesForKeys: nil, options: [], errorHandler: errorHandler) else {
+        guard let enumerator = FileManager().enumerator(at: url, includingPropertiesForKeys: nil, options: [], errorHandler: errorHandler)
+        else {
             fatalError()
         }
         for url in enumerator {


### PR DESCRIPTION
I've checked both builds and they work. However @TimPapler could you check if debugging of the metal code works as expected? I want to make sure I haven't overlooked any command parameters etc.